### PR TITLE
Add `static` keyword to avoid -Wmissing-prototypes (#345)

### DIFF
--- a/changes/sdk/pr.345.gh.OpenXR-SDK-Source.md
+++ b/changes/sdk/pr.345.gh.OpenXR-SDK-Source.md
@@ -1,0 +1,1 @@
+loader: Minor changes to fix a missing-prototypes warning/error.

--- a/src/loader/loader_core.cpp
+++ b/src/loader/loader_core.cpp
@@ -35,7 +35,7 @@
 // Global loader lock to:
 //   1. Ensure ActiveLoaderInstance get and set operations are done atomically.
 //   2. Ensure RuntimeInterface isn't used to unload the runtime while the runtime is in use.
-std::mutex &GetGlobalLoaderMutex() {
+static std::mutex &GetGlobalLoaderMutex() {
     static std::mutex loader_mutex;
     return loader_mutex;
 }
@@ -58,6 +58,8 @@ static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermDestroyDebugUtilsMessengerEXT(
 static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrTermSubmitDebugUtilsMessageEXT(
     XrInstance instance, XrDebugUtilsMessageSeverityFlagsEXT messageSeverity, XrDebugUtilsMessageTypeFlagsEXT messageTypes,
     const XrDebugUtilsMessengerCallbackDataEXT *callbackData);
+static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrGetInstanceProcAddr(XrInstance instance, const char *name,
+                                                                  PFN_xrVoidFunction *function);
 
 // Utility template function meant to validate if a fixed size string contains
 // a null-terminator.


### PR DESCRIPTION
* Add `static` keyword to avoid -Wmissing-prototypes

When compiling the code on mac catalyst (which uses IOS SDK), I ran into a compiler error with `-Werror -Wmissing-prototypes`.

* changelog fragment

Co-authored-by: Ryan Pavlik <ryan.pavlik@collabora.com>